### PR TITLE
Updating selectors for the atom 1.0 api

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -5,12 +5,12 @@
 @import "ui-variables";
 @import "colors";
 
-.editor-colors, :host {
+atom-text-editor, :host {
   background-color: @base03;
   color: @base0;
 }
 
-.editor, :host {
+atom-text-editor, :host {
   .invisible-character,
   .indent-guide {
     color: @base01;
@@ -48,7 +48,7 @@
   }
 }
 
-.bracket-matcher {
+.bracket-matcher .region {
   background-color: @base1;
   opacity: 0.5;
 }

--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -8,9 +8,7 @@
 atom-text-editor, :host {
   background-color: @base03;
   color: @base0;
-}
 
-atom-text-editor, :host {
   .invisible-character,
   .indent-guide {
     color: @base01;


### PR DESCRIPTION
Using the atom-text-editor tag instead of `.editor` and `.editor-colors`. Also fixes the deprecation cop warnings.